### PR TITLE
Change background color to hex format

### DIFF
--- a/iblApi/ibl_swagger_header.json
+++ b/iblApi/ibl_swagger_header.json
@@ -7,7 +7,7 @@
     "description": "BBC iPlayer Business logic Layer",
 	"x-logo": {
 		"url": "http://static.bbci.co.uk/tviplayer/1.101.2/img/navigation/iplayer_pink.svg",
-		"backgroundColor": "white"
+		"backgroundColor": "#FFFFFF"
 	},
     "license": {
       "name": "MIT",

--- a/iblApi/swagger.json
+++ b/iblApi/swagger.json
@@ -7,7 +7,7 @@
     "description": "BBC iPlayer Business logic Layer",
     "x-logo": {
       "url": "http://static.bbci.co.uk/tviplayer/1.101.2/img/navigation/iplayer_pink.svg",
-      "backgroundColor": "white"
+      "backgroundColor": "#FFFFFF"
     },
     "license": {
       "name": "MIT",


### PR DESCRIPTION
Hi @MikeRalphson 
When we developed `x-logo` extension we had only hex format in mind.
But my friend made mistake referencing CSS spec for color definition.
Named colors are CSS specific and hard to support for anything other than CSS/HTML generation.
Official definition of `x-logo` already fixed: 
https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md#logo-object
